### PR TITLE
fix: align minimatch override to ^10.2.4 for P111 sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cross-spawn": "^7.0.5",
     "glob": "^11.1.0",
     "tar": "^7.5.10",
-    "minimatch": "^10.2.3",
+    "minimatch": "^10.2.4",
     "eslint-plugin-react-hooks": {
       "eslint": "$eslint"
     }


### PR DESCRIPTION
Aligns package.json minimatch override from ^10.2.3 to ^10.2.4 to match the Dockerfile P111 patch version. Cosmetic — ^10.2.3 already resolves to 10.2.4+, but this makes the sync explicit.