### PR TITLE
fix: prevent duplicate Docker builds and align minimatch override

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,6 @@ name: Build and Push Docker Images
 
 on:
   push:
-    branches: [main]
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -266,7 +265,7 @@ jobs:
       deployments: write
 
     environment:
-      name: ${{ github.ref == 'refs/heads/main' && 'production' || '' }}
+      name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || '' }}
       url: https://hub.docker.com/r/writenotenow/do-manager
 
     steps:
@@ -313,8 +312,8 @@ jobs:
             latest=auto
           tags: |
             type=semver,pattern=v{{version}}
-            type=raw,value=v${{ steps.version.outputs.version }},enable={{is_default_branch}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=v${{ steps.version.outputs.version }},enable=${{ github.event_name != 'pull_request' }}
+            type=raw,value=latest,enable=${{ github.event_name != 'pull_request' }}
             type=sha,prefix=sha-,format=short
 
       - name: Create and push manifest
@@ -329,7 +328,7 @@ jobs:
 
       # Update Docker Hub description
       - name: Update Docker Hub Description
-        if: github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: peter-evans/dockerhub-description@v5
         continue-on-error: true
         timeout-minutes: 5
@@ -341,7 +340,7 @@ jobs:
           short-description: "Cloudflare DO Manager – Instance Tools, SQL Access, Batch Ops, Global Search, Backups, GitHub SSO."
 
       - name: Deployment Summary
-        if: github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "✅ Successfully published Docker images to production"
           echo "🐳 Registry: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cross-spawn": "^7.0.5",
     "glob": "^11.1.0",
     "tar": "^7.5.10",
-    "minimatch": "^10.2.3",
+    "minimatch": "10.2.4",
     "eslint-plugin-react-hooks": {
       "eslint": "$eslint"
     }


### PR DESCRIPTION
**Two fixes:**

1. **Docker trigger**: Removed ranches: [main] from docker-publish.yml push trigger. Docker images now only build on tag pushes (*) and PR gates — not on every merge to main. This prevents the duplicate Docker builds we were seeing (one from the merge, one from the tag).

2. **minimatch override**: Bumped package.json override from ^10.2.3 to ^10.2.4 to precisely match the Dockerfile P111 patch version.