### PR TITLE
chore: fix remaining @v6 action versions and add node 24 force flag to all workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Force JavaScript-based GitHub Actions in this workflow to run on Node 24.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 permissions:
   contents: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 0 * * 1" # Weekly Monday midnight UTC
 
+env:
+  # Force JavaScript-based GitHub Actions in this workflow to run on Node 24.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   analyze:
     name: Analyze
@@ -25,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,8 @@ on:
 env:
   REGISTRY: docker.io
   IMAGE_NAME: writenotenow/do-manager
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Force JavaScript-based GitHub Actions in this workflow to run on Node 24.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 permissions:
   contents: read

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  # Force JavaScript-based GitHub Actions in this workflow to run on Node 24.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 
@@ -14,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [24.x, 25.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -42,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: "24.x"
           cache: "npm"

--- a/.github/workflows/secrets-scanning.yml
+++ b/.github/workflows/secrets-scanning.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -33,6 +33,4 @@ jobs:
 
       - name: GITLEAKS Secret Scanning
         uses: gitleaks/gitleaks-action@v2
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         continue-on-error: true

--- a/.github/workflows/secrets-scanning.yml
+++ b/.github/workflows/secrets-scanning.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Force JavaScript-based GitHub Actions in this workflow to run on Node 24.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes all remaining actions/checkout@v6 and actions/setup-node@v6 references across codeql.yml and lint-and-test.yml. Also drops Node 25.x from test matrix (non-LTS) and adds FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env flag to all workflows. Addresses Copilot AI review feedback.