### PR TITLE
fix(build): add packages array to pnpm-workspace to fix pnpm install in cloudflare

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   - "esbuild"
   - "workerd"
+packages:
+  - "."


### PR DESCRIPTION
This fixes the build failure on Cloudflare by adding the missing packages array to pnpm-workspace.yaml. Cloudflare's build environment failed because the workspace configuration was invalid without it.